### PR TITLE
feat: allow certain permissions to change welcome and quit messages

### DIFF
--- a/src/main/java/com/xiluiis/WelcomeTitles.java
+++ b/src/main/java/com/xiluiis/WelcomeTitles.java
@@ -6,6 +6,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.command.*;
 
 import com.xiluiis.service.ConfigMessageService;
 import com.xiluiis.service.PlayerRankService;
@@ -13,7 +14,7 @@ import com.xiluiis.service.PlayerRankService;
 public class WelcomeTitles extends JavaPlugin implements Listener
 {
     private ConfigMessageService messageService;
-    private PlayerRankService PlayerRankService;
+    private PlayerRankService playerRankService;
 
     @Override
     public void onEnable() {
@@ -21,7 +22,7 @@ public class WelcomeTitles extends JavaPlugin implements Listener
         getServer().getPluginManager().registerEvents(this, this);
         saveDefaultConfig();
         messageService = new ConfigMessageService(this);
-        PlayerRankService = new PlayerRankService();
+        playerRankService = new PlayerRankService();
     }
 
     @Override
@@ -33,16 +34,46 @@ public class WelcomeTitles extends JavaPlugin implements Listener
     public void onPlayerJoin(PlayerJoinEvent event){
         String playerNameString = event.getPlayer().getName();
         Player player = event.getPlayer();
-        event.setJoinMessage(messageService.createMessage(playerNameString, PlayerRankService.getPlayerRank(player) + "-global-join-message"));
-        player.sendMessage(messageService.createMessage(playerNameString, PlayerRankService.getPlayerRank(player) + "-private-join-message"));
+        event.setJoinMessage(messageService.createMessage(playerNameString, playerRankService.getPlayerRank(player) + "-global-join-message"));
+        player.sendMessage(messageService.createMessage(playerNameString, playerRankService.getPlayerRank(player) + "-private-join-message"));
     }
 
     @EventHandler
     public void onPlayerLeft(PlayerQuitEvent event){
         String playerNameString = event.getPlayer().getName();
         Player player = event.getPlayer();
-        event.setQuitMessage(messageService.createMessage(playerNameString, PlayerRankService.getPlayerRank(player) + "-global-quit-message"));
+        event.setQuitMessage(messageService.createMessage(playerNameString, playerRankService.getPlayerRank(player) + "-global-quit-message"));
     }
+    
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args){
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("Only players can use this command.");
+            return true;
+        }
 
+        if(args.length==0 || (args.length >= 1 && args[0].equalsIgnoreCase("help"))){
+             if(playerRankService.isAllowedToSet(sender)){
+                sender.sendMessage("Executing help premium options");
+             }
+                sender.sendMessage("Executing help options");
+                return true;
+            }
+
+        if(args.length >= 1){
+            if(args[0].equalsIgnoreCase("set")){
+                if(playerRankService.isAllowedToSet(sender)){
+                    sender.sendMessage("Executing set command");
+                    messageService.changeMessage(sender.getName(), "admin-global-join-message", "Test");
+                    return true;
+                }else{
+                    sender.sendMessage("You don't have permissions to execute this command");
+                    return true;
+                }
+            }
+        }
+        sender.sendMessage("Unknown command. Use /welcometitles help to see possible commands");
+        return true;
+    }
 
 }

--- a/src/main/java/com/xiluiis/service/ConfigMessageService.java
+++ b/src/main/java/com/xiluiis/service/ConfigMessageService.java
@@ -12,4 +12,9 @@ public class ConfigMessageService implements MessageService{
         String message = plugin.getConfig().getString(pathString).replace("%player%", playerNameString);
         return message;
     }
+
+    public void changeMessage(String playerNameString, String pathString, String newText){
+        plugin.getConfig().set(pathString,newText);
+        plugin.saveConfig();
+    }
 }

--- a/src/main/java/com/xiluiis/service/MessageService.java
+++ b/src/main/java/com/xiluiis/service/MessageService.java
@@ -2,4 +2,5 @@ package com.xiluiis.service;
 
 public interface MessageService {
     String createMessage(String playerNameString, String pathString);
+    void changeMessage(String playerNameString, String pathString, String newText);
 }

--- a/src/main/java/com/xiluiis/service/PlayerRankService.java
+++ b/src/main/java/com/xiluiis/service/PlayerRankService.java
@@ -1,8 +1,10 @@
 package com.xiluiis.service;
 
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 public class PlayerRankService implements RankService {
+
     public String getPlayerRank(Player player){
         if(player.hasPermission("welcometitles.vip")){
             return "vip";
@@ -17,5 +19,8 @@ public class PlayerRankService implements RankService {
         }
         return "default";
     }
-    
+ 
+    public boolean isAllowedToSet(CommandSender sender){
+        return sender.hasPermission("welcometitles.vip") ||  sender.hasPermission("welcometitles.admin") || sender.isOp();
+    }
 }

--- a/src/main/java/com/xiluiis/service/RankService.java
+++ b/src/main/java/com/xiluiis/service/RankService.java
@@ -1,6 +1,8 @@
 package com.xiluiis.service;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 public interface RankService {
     String getPlayerRank(Player player);
+    boolean isAllowedToSet(CommandSender sender);
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,8 +6,8 @@ version: 1.0.0-beta
 api-version: 1.20
 commands:
   welcometitles:
-    description: test
-    usage: test
+    description: Command to handle WelcomeTitles parameters
+    usage: /welcometitles <help|set|get> [...]
 permissions:
   welcometitles.default:
     description: Messages for default players.


### PR DESCRIPTION
- Added command handling for /welcometitles set
- Only admin and vip (or OP) can use the set subcommand
- Added changeMessage method to ConfigMessageService to update config values
- Improved permission checks and help command structure